### PR TITLE
Added basic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
       * [Sentences](#sentences)
       * [Comments](#comments)
       * [Variables](#variables)
+      * [Functions (Custom Sentences)](#functions-custom-sentences)
    * [Examples](#examples)
       * [Hello, World!](#hello-world)
       * [Variables](#variables-1)
@@ -123,6 +124,19 @@ The default value will be empty, you can set the value with:
 ```
 set my-var to "hello"
 ```
+
+## Functions (Custom Sentences)
+
+Custom sentences can be defined by using the `:` character:
+
+```
+print everything:
+	display "Hello"
+	display "World"
+```
+
+The whitespace is not required. However, it is easier to read when content of
+functions are indented with spaces or tabs.
 
 # Examples
 

--- a/examples/custom-sentences.bento
+++ b/examples/custom-sentences.bento
@@ -1,0 +1,6 @@
+print everything
+print everything
+
+print everything:
+	display "Hello"
+	display "World"

--- a/function.go
+++ b/function.go
@@ -1,0 +1,11 @@
+package main
+
+type Function struct {
+	Sentences []*Sentence
+}
+
+func (fn *Function) Run(program *Program) {
+	for _, sentence := range fn.Sentences {
+		sentence.Run(program)
+	}
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -18,16 +18,23 @@ func TestParse(t *testing.T) {
 			bento: "",
 			expected: &Program{
 				Variables: map[string]*Variable{},
+				Functions: map[string]*Function{
+					"start": {},
+				},
 			},
 		},
 		"Display": {
 			bento: `Display "Hello, World!"`,
 			expected: &Program{
 				Variables: map[string]*Variable{},
-				Sentences: []*Sentence{
-					System.SentenceForSyntax("display ?", []interface{}{
-						"Hello, World!",
-					}),
+				Functions: map[string]*Function{
+					"start": {
+						Sentences: []*Sentence{
+							System.SentenceForSyntax("display ?", []interface{}{
+								"Hello, World!",
+							}),
+						},
+					},
 				},
 			},
 		},
@@ -35,13 +42,17 @@ func TestParse(t *testing.T) {
 			bento: "Display \"hello\"\ndisplay \"twice!\"",
 			expected: &Program{
 				Variables: map[string]*Variable{},
-				Sentences: []*Sentence{
-					System.SentenceForSyntax("display ?", []interface{}{
-						"hello",
-					}),
-					System.SentenceForSyntax("display ?", []interface{}{
-						"twice!",
-					}),
+				Functions: map[string]*Function{
+					"start": {
+						Sentences: []*Sentence{
+							System.SentenceForSyntax("display ?", []interface{}{
+								"hello",
+							}),
+							System.SentenceForSyntax("display ?", []interface{}{
+								"twice!",
+							}),
+						},
+					},
 				},
 			},
 		},
@@ -54,6 +65,9 @@ func TestParse(t *testing.T) {
 						Value: "",
 					},
 				},
+				Functions: map[string]*Function{
+					"start": {},
+				},
 			},
 		},
 		"Declare2": {
@@ -65,10 +79,56 @@ func TestParse(t *testing.T) {
 						Value: "",
 					},
 				},
-				Sentences: []*Sentence{
-					System.SentenceForSyntax("display ?", []interface{}{
-						VariableReference("foo"),
-					}),
+				Functions: map[string]*Function{
+					"start": {
+						Sentences: []*Sentence{
+							System.SentenceForSyntax("display ?", []interface{}{
+								VariableReference("foo"),
+							}),
+						},
+					},
+				},
+			},
+		},
+		"Function1": {
+			bento: "display \"hi\"\ndo something:\ndisplay \"ok\"",
+			expected: &Program{
+				Variables: map[string]*Variable{},
+				Functions: map[string]*Function{
+					"start": {
+						Sentences: []*Sentence{
+							System.SentenceForSyntax("display ?", []interface{}{
+								"hi",
+							}),
+						},
+					},
+					"do something": {
+						Sentences: []*Sentence{
+							System.SentenceForSyntax("display ?", []interface{}{
+								"ok",
+							}),
+						},
+					},
+				},
+			},
+		},
+		"Function2": {
+			bento: "do something\ndo something:\ndisplay \"ok\"",
+			expected: &Program{
+				Variables: map[string]*Variable{},
+				Functions: map[string]*Function{
+					"start": {
+						Sentences: []*Sentence{
+							{},
+						},
+					},
+					"do something": {
+						Sentences: []*Sentence{
+							System.SentenceForSyntax("display ?", []interface{}{
+								"ok",
+							}),
+						},
+					},
 				},
 			},
 		},

--- a/program.go
+++ b/program.go
@@ -2,13 +2,11 @@ package main
 
 type Program struct {
 	Variables map[string]*Variable
-	Sentences []*Sentence
+	Functions map[string]*Function
 }
 
 func (program *Program) Run() {
-	for _, sentence := range program.Sentences {
-		sentence.Run(program)
-	}
+	program.Functions["start"].Run(program)
 }
 
 func (program *Program) ValueOf(val interface{}) interface{} {
@@ -19,4 +17,17 @@ func (program *Program) ValueOf(val interface{}) interface{} {
 	default:
 		return val
 	}
+}
+
+func (program *Program) SentenceForSyntax(syntax string, args []interface{}) *Sentence {
+	if _, ok := program.Functions[syntax]; ok {
+		return &Sentence{
+			Handler: func(program *Program, _ []interface{}) {
+				program.Functions[syntax].Run(program)
+			},
+			Args: args,
+		}
+	}
+
+	return nil
 }

--- a/token.go
+++ b/token.go
@@ -10,6 +10,7 @@ const (
 	TokenKindWord = iota
 	TokenKindText
 	TokenKindEndline
+	TokenKindColon
 )
 
 type Token struct {
@@ -28,6 +29,11 @@ func Tokenize(r io.Reader) (tokens []Token, err error) {
 
 	for i := 0; i < len(entire); i++ {
 		switch entire[i] {
+		case ':':
+			tokens = appendWord(tokens, &word)
+			tokens = append(tokens, Token{TokenKindColon, ""})
+			tokens = appendEndline(tokens)
+
 		case '#':
 			tokens = appendEndline(tokens)
 			for ; i < len(entire); i++ {
@@ -51,7 +57,7 @@ func Tokenize(r io.Reader) (tokens []Token, err error) {
 				}
 			}
 
-		case ' ':
+		case ' ', '\t':
 			tokens = appendWord(tokens, &word)
 
 		default:

--- a/token_test.go
+++ b/token_test.go
@@ -119,6 +119,39 @@ func TestTokenize(t *testing.T) {
 				{TokenKindEndline, ""},
 			},
 		},
+		"Function1": {
+			bento: "do something:\nsomething else",
+			expected: []Token{
+				{TokenKindWord, "do"},
+				{TokenKindWord, "something"},
+				{TokenKindColon, ""},
+				{TokenKindEndline, ""},
+				{TokenKindWord, "something"},
+				{TokenKindWord, "else"},
+				{TokenKindEndline, ""},
+			},
+		},
+		"Function2": {
+			bento: "do something: something else",
+			expected: []Token{
+				{TokenKindWord, "do"},
+				{TokenKindWord, "something"},
+				{TokenKindColon, ""},
+				{TokenKindEndline, ""},
+				{TokenKindWord, "something"},
+				{TokenKindWord, "else"},
+				{TokenKindEndline, ""},
+			},
+		},
+		"Tabs": {
+			bento: `	foo	bar "baz	"	`,
+			expected: []Token{
+				{TokenKindWord, "foo"},
+				{TokenKindWord, "bar"},
+				{TokenKindText, "baz	"},
+				{TokenKindEndline, ""},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			actual, err := Tokenize(strings.NewReader(test.bento))


### PR DESCRIPTION
Custom sentences can be defined by using the `:` character:

    print everything:
        display "Hello"
        display "World"

The whitespace is not required. However, it is easier to read when content of functions are indented with spaces or tabs.