### PR TITLE
Added System backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
       * [Functions (Custom Sentences)](#functions-custom-sentences)
       * [Controlling Flow](#controlling-flow)
          * [Decisions (if/unless)](#decisions-ifunless)
+   * [Backends](#backends)
+      * [System](#system)
    * [Examples](#examples)
       * [Hello, World!](#hello-world)
       * [Variables](#variables-1)
@@ -237,6 +239,38 @@ following is not allowed, and will return an error:
 
 ```
 "123" = 123
+```
+
+# Backends
+
+A backend performs the tasks described in the bento program.
+
+## System
+
+The system backend provides direct access to running programs on the host
+machine.
+
+- `run system command <command>`: Run the `command` and send all stdout and
+stderr to the console.
+
+- `run system command <command> output into <output>`: Run the `command` and
+capture all of the stdout and stderr into the `output`.
+
+- `run system command <command> status code into <status>`: Run the `command`
+and discard and stdout and stderr. Instead capture the status code returned in
+`status`.
+
+- `run system command <command> output into <output> status code into <status>`:
+Run the `command` and capture the stdout and stderr into `output` as well as the
+status code returned into `status`.
+
+Example:
+
+```bento
+start:
+	declare echo-result is number
+	run system command "echo hello" status code into echo-result
+	unless echo-result = 0, display "command failed!"
 ```
 
 # Examples

--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ func main() {
 		compiledProgram := compiler.Compile()
 
 		vm := NewVirtualMachine(compiledProgram)
-		vm.Run()
+		err = vm.Run()
+
+		if err != nil {
+			log.Fatalln(err)
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -42,9 +43,16 @@ func TestBentoFiles(t *testing.T) {
 			err = vm.Run()
 			require.NoError(t, err)
 
-			expectedFilePath := dir + strings.Replace(fileInfo.Name(), ".bento", ".txt", -1)
+			// There can be a specific expectation file depending on the OS.
+			expectedFilePath := dir + strings.Replace(fileInfo.Name(), ".bento", "."+runtime.GOOS+".txt", -1)
 			expectedData, err := ioutil.ReadFile(expectedFilePath)
-			require.NoError(t, err)
+
+			if err != nil {
+				// Fallback to generic expectation file.
+				expectedFilePath = dir + strings.Replace(fileInfo.Name(), ".bento", ".txt", -1)
+				expectedData, err = ioutil.ReadFile(expectedFilePath)
+				require.NoError(t, err)
+			}
 
 			assert.Equal(t, string(expectedData), vm.out.(*bytes.Buffer).String())
 		})

--- a/tests/system.bento
+++ b/tests/system.bento
@@ -1,0 +1,19 @@
+start:
+	declare echo-result is text
+	declare echo-status is number
+
+	run system command "echo hi"
+	run system command "nosuchcommand"
+
+	run system command "echo hello" output into echo-result
+	display "---1"
+	display echo-result
+
+	run system command "nosuchcommand" status code into echo-status
+	display "---2"
+	display echo-status
+
+	run system command "exit 52" output into echo-result status code into echo-status
+	display "---3"
+	display echo-result
+	display echo-status

--- a/tests/system.darwin.txt
+++ b/tests/system.darwin.txt
@@ -1,0 +1,10 @@
+hi
+sh: nosuchcommand: command not found
+---1
+hello
+
+---2
+127.000000
+---3
+
+52.000000

--- a/tests/system.linux.txt
+++ b/tests/system.linux.txt
@@ -1,0 +1,10 @@
+hi
+sh: 1: nosuchcommand: not found
+---1
+hello
+
+---2
+127.000000
+---3
+
+52.000000

--- a/vm.go
+++ b/vm.go
@@ -49,6 +49,11 @@ func (vm *VirtualMachine) Run() error {
 func (vm *VirtualMachine) call(syntax string, args []int) error {
 	fn := vm.program.Functions[syntax]
 
+	// TODO: This should be picked up in compile time.
+	if fn == nil {
+		return fmt.Errorf("no such function: %s", syntax)
+	}
+
 	// Expand the memory to accommodate the call.
 	vm.memory = append(vm.memory, fn.Variables...)
 
@@ -174,6 +179,10 @@ func (vm *VirtualMachine) SetArg(index int, value interface{}) {
 
 func (vm *VirtualMachine) GetNumber(index int) *big.Rat {
 	return vm.memory[vm.previousOffset+index].(*big.Rat)
+}
+
+func (vm *VirtualMachine) GetText(index int) *string {
+	return vm.memory[vm.previousOffset+index].(*string)
 }
 
 func (vm *VirtualMachine) GetArgType(index int) string {


### PR DESCRIPTION
The system backend provides direct access to running programs on the host
machine.

- `run system command <command>`: Run the `command` and send all stdout and
stderr to the console.

- `run system command <command> output into <output>`: Run the `command` and
capture all of the stdout and stderr into the `output`.

- `run system command <command> status code into <status>`: Run the `command`
and discard and stdout and stderr. Instead capture the status code returned in
`status`.

- `run system command <command> output into <output> status code into <status>`:
Run the `command` and capture the stdout and stderr into `output` as well as the
status code returned into `status`.

Example:

    start:
        declare echo-result is number
        run system command "echo hello" status code into echo-result
        unless echo-result = 0, display "command failed!"

Fixes #29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/bento/35)
<!-- Reviewable:end -->
