### PR TITLE
Wrap sentences on ","

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
    * [Language](#language)
       * [File Structure](#file-structure)
       * [Sentences](#sentences)
+         * [Wrapping Long Sentences](#wrapping-long-sentences)
       * [Comments](#comments)
       * [Variables](#variables)
          * [Blackhole](#blackhole)
@@ -125,10 +126,11 @@ new line. For example:
 display "Hello"
 ```
 
-Long sentences can be broken up into multiple lines using `...` at the end of
-each line, excluding the last line:
+### Wrapping Long Sentences
 
-```
+You can explicitly use `...` at the end of the line to indicate a continuation:
+
+```bento
 this is a really long...
 	sentence that should go...
 	over multiple lines
@@ -136,6 +138,15 @@ this is a really long...
 
 Indentation between lines does not make an difference. However, it is easier to
 read when following lines are indented.
+
+Sentences can also contains new lines if the line ends with a `,`. This is
+useful for long inline statements:
+
+```bento
+if my-name != "John",
+  display "oops!",
+  otherwise display "All good."
+```
 
 ## Comments
 

--- a/parser.go
+++ b/parser.go
@@ -331,7 +331,7 @@ func (parser *Parser) consumeVariableIsTypeList() (list map[string]*VariableDefi
 
 		list[definition.Name] = definition
 
-		_, err = parser.consumeToken(TokenKindComma)
+		err = parser.consumeComma()
 		if err != nil {
 			break
 		}
@@ -629,7 +629,7 @@ func (parser *Parser) consumeIf(varMap map[string]*VariableDefinition) (ifStmt *
 		}
 	}
 
-	_, err = parser.consumeToken(TokenKindComma)
+	err = parser.consumeComma()
 	if err != nil {
 		return
 	}
@@ -645,7 +645,7 @@ func (parser *Parser) consumeIf(varMap map[string]*VariableDefinition) (ifStmt *
 		return
 	}
 
-	_, err = parser.consumeToken(TokenKindComma)
+	err = parser.consumeComma()
 	if err != nil {
 		return
 	}
@@ -705,6 +705,18 @@ func (parser *Parser) consumeOperator() (string, error) {
 	return operatorToken.Value, nil
 }
 
+func (parser *Parser) consumeComma() error {
+	_, err := parser.consumeToken(TokenKindComma)
+	if err != nil {
+		return err
+	}
+
+	// Ignore the error as the new line is optional.
+	_, _ = parser.consumeToken(TokenKindEndOfLine)
+
+	return nil
+}
+
 func (parser *Parser) consumeWhile(varMap map[string]*VariableDefinition) (whileStmt *While, err error) {
 	originalOffset := parser.offset
 	defer func() {
@@ -738,7 +750,7 @@ func (parser *Parser) consumeWhile(varMap map[string]*VariableDefinition) (while
 		}
 	}
 
-	_, err = parser.consumeToken(TokenKindComma)
+	err = parser.consumeComma()
 	if err != nil {
 		return
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -835,6 +835,55 @@ var parserTests = map[string]struct {
 			},
 		},
 	},
+	"MultilineIf": {
+		bento: "start:\nif something,\n  next line\ndisplay hi",
+		expected: &Program{
+			Functions: map[string]*Function{
+				"start": {
+					Definition: &Sentence{Words: []interface{}{"start"}},
+					Statements: []Statement{
+						&If{
+							Question: &Sentence{
+								Words: []interface{}{"something"},
+							},
+							True: &Sentence{
+								Words: []interface{}{"next", "line"},
+							},
+						},
+						&Sentence{
+							Words: []interface{}{"display", "hi"},
+						},
+					},
+				},
+			},
+		},
+	},
+	"MultilineIf2": {
+		bento: "start:\nif something,\n  next line,\n  otherwise foo\ndisplay hi",
+		expected: &Program{
+			Functions: map[string]*Function{
+				"start": {
+					Definition: &Sentence{Words: []interface{}{"start"}},
+					Statements: []Statement{
+						&If{
+							Question: &Sentence{
+								Words: []interface{}{"something"},
+							},
+							True: &Sentence{
+								Words: []interface{}{"next", "line"},
+							},
+							False: &Sentence{
+								Words: []interface{}{"foo"},
+							},
+						},
+						&Sentence{
+							Words: []interface{}{"display", "hi"},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser_Parse(t *testing.T) {


### PR DESCRIPTION
Sentences can also contains new lines if the line ends with a `,`. This is useful for long inline statements:

    if my-name != "John",
      display "oops!",
      otherwise display "All good."

Fixes #49

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/bento/53)
<!-- Reviewable:end -->
