### PR TITLE
Display with multiple arguments

### DIFF
--- a/examples/am-pm.bento
+++ b/examples/am-pm.bento
@@ -1,0 +1,13 @@
+Start:
+  Say hello to "Jane"
+  Say hello to "David"
+
+Say hello to persons-name (persons-name is text):
+  If it is the afternoon,
+    display "Good afternoon, " persons-name "!",
+    otherwise display "Good morning, " persons-name "!"
+
+It is the afternoon?
+  Declare am-or-pm is text
+  Run system command "printf `date +'%p'`" output into am-or-pm
+  If am-or-pm = "PM", yes


### PR DESCRIPTION
This is a really dodgy hack until we can properly support varargs. Each of the arguments will be printed with no space between them and a single newline will be written after any (including zero) arguments.

I have included examples/am-pm.bento to demonstrate this.